### PR TITLE
ci: split release into firmware and PCB tag-triggered workflows

### DIFF
--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -55,7 +55,7 @@ jobs:
         # forward-looking d'une version non-latest. Guard empty rend l'erreur
         # bruyante au lieu de silencieuse.
         run: |
-          prev_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v -Fx "${{ github.ref_name }}" | head -n1)
+          prev_tag=$(git tag --list 'v[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*' --sort=-v:refname | grep -v -Fx "${{ github.ref_name }}" | head -n1)
           if [ -z "$prev_tag" ]; then
             echo "::error::No previous v-* tag found. Push a baseline firmware tag first."
             exit 1

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release firmware
 
 on:
   push:
@@ -6,9 +6,15 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 # contents: write requis pour (a) release-action, (b) auto-commit du CHANGELOG.
-# Rien d'autre — pas d'id-token, pas de packages.
 permissions:
   contents: write
+
+# Concurrency group partagé avec release-pcb.yml — sérialise tout accès à `main`
+# en cas de push simultané `git push origin main v0.2.0 pcb-0.1.1`, éliminant
+# toute fenêtre de race sur l'auto-commit du CHANGELOG.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -17,23 +23,24 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          # requarks/changelog-action et git describe ont besoin de l'historique complet.
+          # requarks/changelog-action et git tag --list ont besoin de l'historique complet.
           fetch-depth: 0
 
       - name: Verify tag commit is on origin/main
         # Garde A4 : empêche un tag poussé depuis une feat branch ou un commit
         # détaché de polluer CHANGELOG.md sur main avec une entrée fantôme.
+        # Refname-exact match (pas `grep 'origin/main$'`) pour éviter les faux positifs
+        # si un second remote ou une branche `feat-main` existe.
         run: |
           git fetch origin main --quiet
-          if ! git branch -r --contains "${{ github.sha }}" | grep -q 'origin/main$'; then
+          if ! git branch -r --contains "${{ github.sha }}" --format='%(refname)' | grep -Fxq 'refs/remotes/origin/main'; then
             echo "::error::Tag ${{ github.ref_name }} points to a commit absent from origin/main. Refusing to release."
             exit 1
           fi
 
-      # Garde anti-remplacement silencieux : un force-retag sur un tag déjà publié
-      # écraserait la release existante sans trace. On exige une suppression
-      # explicite de la release avant de pouvoir retagger.
       - name: Fail fast if release already exists
+        # Garde anti-remplacement silencieux : un force-retag sur un tag déjà publié
+        # écraserait la release existante sans trace.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -42,75 +49,69 @@ jobs:
             exit 1
           fi
 
+      - name: Compute previous firmware tag
+        id: prev
+        # Skip-by-name (pas par position) pour rester correct sur un retag
+        # forward-looking d'une version non-latest. Guard empty rend l'erreur
+        # bruyante au lieu de silencieuse.
+        run: |
+          prev_tag=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v -Fx "${{ github.ref_name }}" | head -n1)
+          if [ -z "$prev_tag" ]; then
+            echo "::error::No previous v-* tag found. Push a baseline firmware tag first."
+            exit 1
+          fi
+          echo "prev_tag=$prev_tag" >> "$GITHUB_OUTPUT"
+          echo "- Previous firmware tag: $prev_tag" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Generate release notes + update CHANGELOG
         id: changelog
         uses: requarks/changelog-action@b78a3354a01f4a1affb484b9264b506a815c46b1  # v1.10.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref_name }}
-          # excludeScopes: 'changelog' filtre le commit auto-généré `docs(changelog): update CHANGELOG.md …`
-          # pour éviter qu'il apparaisse dans les release notes du tag suivant (A5).
-          # excludeTypes: 'chore,style,build' coupe le bruit standard.
+          fromTag: ${{ github.ref_name }}
+          toTag: ${{ steps.prev.outputs.prev_tag }}
+          changelogFilePath: CHANGELOG.md
+          # excludeTypes hérité de l'ancien release.yml pour préserver le filtre de bruit.
           excludeTypes: chore,style,build
-          excludeScopes: changelog
+          # excludeScopes : `changelog` filtre le commit auto-généré ; `pcb` tient les
+          # commits PCB hors des notes firmware (ils sont documentés côté pcb-*).
+          excludeScopes: changelog,pcb
 
-      - name: Zip Gerbers
-        run: |
-          cd pcb/src && zip -r ../../gerber.zip .
-          echo "- Zipped pcb/src into gerber.zip for ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-
-      - name: Validate gerber.zip contents
-        run: |
-          # Garde C12 : refuse de publier un asset vide (ex: pcb/src/ accidentellement vidé).
-          if ! unzip -l gerber.zip | grep -qE '\.(GTL|GBL|GKO|GBS|GTO|GTS|DRL)$'; then
-            echo "::error::gerber.zip is missing Gerber/DRL files — refusing to publish."
-            exit 1
-          fi
-          echo "- Validated gerber.zip has Gerber/DRL entries" >> $GITHUB_STEP_SUMMARY
-
-      - name: Compose release body (prepend PCB-unchanged note when applicable)
+      - name: Compose release body
         id: release_notes
-        # A2 : si aucun commit depuis le tag précédent ne touche pcb/, préfixer
-        # le body d'une note pour dissiper l'ambiguïté de provenance (le zip est
-        # identique au release précédent).
         env:
           CHANGELOG_BODY: ${{ steps.changelog.outputs.changes }}
         run: |
           delimiter="BODY_$(openssl rand -hex 16)"
-          prev_tag=$(git describe --tags --abbrev=0 "${{ github.ref_name }}^" 2>/dev/null || echo "")
-          pcb_note=""
-          if [ -n "$prev_tag" ] && [ -z "$(git log --name-only "${prev_tag}..${{ github.sha }}" -- pcb/ | grep .)" ]; then
-            pcb_note="> **Note matérielle** : PCB inchangé depuis ${prev_tag}. Le \`gerber.zip\` attaché est identique à celui du précédent release."$'\n\n'
-          fi
           {
             echo "body<<${delimiter}"
-            printf '%s' "$pcb_note"
             printf '%s\n' "$CHANGELOG_BODY"
             echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
-          echo "- Composed release body for ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Composed release body for ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit CHANGELOG.md update
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
         with:
           branch: main
-          # Scope `changelog` matche l'excludeScopes du prochain run (cf. A5).
+          # Scope `changelog` matche l'excludeScopes du prochain run pour filtrage.
           # `[skip ci]` coupe le déclenchement de validate.yml sur ce commit.
           commit_message: 'docs(changelog): update CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
           file_pattern: CHANGELOG.md
 
       - name: Log CHANGELOG commit to step summary
-        run: echo "- CHANGELOG committed to main for ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+        run: echo "- CHANGELOG committed to main for ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create or update GitHub Release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           allowUpdates: true
+          # `legacy` délègue à la comparaison semver de GitHub, qui garde le tag
+          # sémantiquement le plus récent en "latest" peu importe l'ordre de push.
           makeLatest: legacy
           name: ${{ github.ref_name }}
           body: ${{ steps.release_notes.outputs.body }}
-          artifacts: gerber.zip
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log release creation to step summary
-        run: echo "- GitHub Release ${{ github.ref_name }} created/updated with gerber.zip" >> $GITHUB_STEP_SUMMARY
+        run: echo "- GitHub Release ${{ github.ref_name }} created/updated (firmware, no asset)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-pcb.yml
+++ b/.github/workflows/release-pcb.yml
@@ -51,7 +51,7 @@ jobs:
         id: prev
         # Skip-by-name + empty-guard (voir release-firmware.yml).
         run: |
-          prev_tag=$(git tag --list 'pcb-[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v -Fx "${{ github.ref_name }}" | head -n1)
+          prev_tag=$(git tag --list 'pcb-[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*' --sort=-v:refname | grep -v -Fx "${{ github.ref_name }}" | head -n1)
           if [ -z "$prev_tag" ]; then
             echo "::error::No previous pcb-* tag found. The pcb-0.1.0 seed baseline tag must exist — see README 'Couper une release PCB'."
             exit 1
@@ -80,7 +80,7 @@ jobs:
       - name: Validate gerber.zip contents
         # Garde C12 : refuse de publier un asset vide (ex: pcb/src/ accidentellement vidé).
         run: |
-          if ! unzip -l gerber.zip | grep -qE '\.(GTL|GBL|GKO|GBS|GTO|GTS|DRL)$'; then
+          if ! unzip -l gerber.zip | grep -iqE '\.(GTL|GBL|GKO|GBS|GTO|GTS|DRL)$'; then
             echo "::error::gerber.zip is missing Gerber/DRL files — refusing to publish."
             exit 1
           fi

--- a/.github/workflows/release-pcb.yml
+++ b/.github/workflows/release-pcb.yml
@@ -1,0 +1,126 @@
+name: Release PCB
+
+on:
+  push:
+    tags:
+      - 'pcb-[0-9]+.[0-9]+.[0-9]+'
+
+# contents: write requis pour (a) release-action, (b) auto-commit du CHANGELOG.
+permissions:
+  contents: write
+
+# Concurrency group partagé avec release-firmware.yml — voir cette workflow
+# pour la rationale.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # Guard seed-baseline : `pcb-0.1.0` est un baseline annotated tag posé sur le
+    # commit d'import monorepo. Un push (accidentel ou volontaire) ne doit pas
+    # créer de release — il sert uniquement d'ancre pour `git tag --list 'pcb-*'`.
+    # Rend la workflow idempotente à un push post-merge du seed.
+    if: github.ref_name != 'pcb-0.1.0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag commit is on origin/main
+        # Refname-exact match (voir release-firmware.yml pour la rationale).
+        run: |
+          git fetch origin main --quiet
+          if ! git branch -r --contains "${{ github.sha }}" --format='%(refname)' | grep -Fxq 'refs/remotes/origin/main'; then
+            echo "::error::Tag ${{ github.ref_name }} points to a commit absent from origin/main. Refusing to release."
+            exit 1
+          fi
+
+      - name: Fail fast if release already exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "::error::Release ${{ github.ref_name }} already exists. Delete it explicitly (gh release delete ${{ github.ref_name }} --yes) before retagging."
+            exit 1
+          fi
+
+      - name: Compute previous PCB tag
+        id: prev
+        # Skip-by-name + empty-guard (voir release-firmware.yml).
+        run: |
+          prev_tag=$(git tag --list 'pcb-[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v -Fx "${{ github.ref_name }}" | head -n1)
+          if [ -z "$prev_tag" ]; then
+            echo "::error::No previous pcb-* tag found. The pcb-0.1.0 seed baseline tag must exist — see README 'Couper une release PCB'."
+            exit 1
+          fi
+          echo "prev_tag=$prev_tag" >> "$GITHUB_OUTPUT"
+          echo "- Previous PCB tag: $prev_tag" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate release notes + update pcb/CHANGELOG.md
+        id: changelog
+        uses: requarks/changelog-action@b78a3354a01f4a1affb484b9264b506a815c46b1  # v1.10.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fromTag: ${{ github.ref_name }}
+          toTag: ${{ steps.prev.outputs.prev_tag }}
+          changelogFilePath: pcb/CHANGELOG.md
+          excludeTypes: chore,style,build
+          # Un tag `pcb-*` implique que le PCB a changé — on ne filtre pas les
+          # scopes firmware qui pourraient coexister dans le range.
+          excludeScopes: changelog
+
+      - name: Zip Gerbers
+        run: |
+          cd pcb/src && zip -r ../../gerber.zip .
+          echo "- Zipped pcb/src into gerber.zip for ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate gerber.zip contents
+        # Garde C12 : refuse de publier un asset vide (ex: pcb/src/ accidentellement vidé).
+        run: |
+          if ! unzip -l gerber.zip | grep -qE '\.(GTL|GBL|GKO|GBS|GTO|GTS|DRL)$'; then
+            echo "::error::gerber.zip is missing Gerber/DRL files — refusing to publish."
+            exit 1
+          fi
+          echo "- Validated gerber.zip has Gerber/DRL entries" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Compose release body
+        id: release_notes
+        env:
+          CHANGELOG_BODY: ${{ steps.changelog.outputs.changes }}
+        run: |
+          delimiter="BODY_$(openssl rand -hex 16)"
+          {
+            echo "body<<${delimiter}"
+            printf '%s\n' "$CHANGELOG_BODY"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+          echo "- Composed release body for ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit pcb/CHANGELOG.md update
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9  # v7.1.0
+        with:
+          branch: main
+          # Commit message nomme explicitement le fichier touché pour l'audit trail.
+          commit_message: 'docs(changelog): update pcb/CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
+          file_pattern: pcb/CHANGELOG.md
+
+      - name: Log CHANGELOG commit to step summary
+        run: echo "- pcb/CHANGELOG.md committed to main for ${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create or update GitHub Release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
+        with:
+          allowUpdates: true
+          # `makeLatest: false` garde le badge "latest release" sur le firmware —
+          # la release PCB reste visible mais n'écrase jamais la plus récente firmware.
+          makeLatest: false
+          name: ${{ github.ref_name }}
+          body: ${{ steps.release_notes.outputs.body }}
+          artifacts: gerber.zip
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log release creation to step summary
+        run: echo "- GitHub Release ${{ github.ref_name }} created/updated with gerber.zip (PCB, makeLatest:false)" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Le PCB qui héberge l'ESP32 et ses capteurs est sous [pcb/](pcb/). Voir [pcb/REA
 
 ![Vue 2D du PCB](pcb/images/Vue_2D.svg)
 
-Les Gerbers prêts pour fabrication sont publiés en tant qu'asset `gerber.zip` sur chaque [GitHub release](https://github.com/gaetanars/FrangiPool/releases) — téléchargez-les et envoyez-les au fabricant de votre choix (JLCPCB, PCBWay, etc.).
+Les Gerbers prêts pour fabrication sont publiés en tant qu'asset `gerber.zip` sur les [GitHub releases PCB](https://github.com/gaetanars/FrangiPool/releases) (tags `pcb-*.*.*`) — téléchargez-les et envoyez-les au fabricant de votre choix (JLCPCB, PCBWay, etc.). Les releases firmware (tags `v*.*.*`) n'attachent pas de Gerbers ; utiliser la dernière release PCB pour la fabrication.
 
 ## Couper une release
 
@@ -292,7 +292,7 @@ Le tag doit matcher la regex `pcb-[0-9]+.[0-9]+.[0-9]+`. Le premier tag PCB sous
 
 > **Seed baseline tag — `pcb-0.1.0`**
 >
-> Le tag `pcb-0.1.0` est un seed baseline immutable posé sur le commit d'import monorepo (`7ea5eab feat(pcb): import hardware design from frangipool/pcb@cfd2e9f`). **NE JAMAIS le supprimer, le déplacer, ni le retagger.** Il sert d'ancre pour `git tag --list 'pcb-*'` et sa disparition casserait le `prev_tag` lookup de toutes les releases PCB futures. Si le tag est pushé par erreur (p.ex. après merge), `release-pcb.yml` saute proprement via son guard `if: github.ref_name != 'pcb-0.1.0'` — aucune release créée.
+> Le tag `pcb-0.1.0` est un seed baseline immutable posé sur le commit `b5573bb feat: fusionner frangipool/pcb dans le monorepo + release workflow (#7)` — le squash-merge où `pcb/` a atterri sur `main`. **NE JAMAIS le supprimer, le déplacer, ni le retagger.** Il sert d'ancre pour `git tag --list 'pcb-*'` et sa disparition casserait le `prev_tag` lookup de toutes les releases PCB futures. Si le tag est pushé par erreur (p.ex. après merge), `release-pcb.yml` saute proprement via son guard `if: github.ref_name != 'pcb-0.1.0'` — aucune release créée.
 
 **Retag forward-looking** d'un tag PCB (`pcb-0.1.1` ou suivant) : même procédure que pour firmware, substituer le prefix.
 

--- a/README.md
+++ b/README.md
@@ -253,17 +253,55 @@ Les Gerbers prêts pour fabrication sont publiés en tant qu'asset `gerber.zip` 
 
 ## Couper une release
 
-Une release unifiée (firmware + `gerber.zip`) est produite à chaque tag `v*.*.*` par [.github/workflows/release.yml](.github/workflows/release.yml).
+Firmware et PCB ont des cycles de vie indépendants. Deux workflows tag-triggered, miroirs, produisent chacune leurs releases :
+
+- [.github/workflows/release-firmware.yml](.github/workflows/release-firmware.yml) — tags `v*.*.*`, écrit dans `CHANGELOG.md`, aucun asset attaché.
+- [.github/workflows/release-pcb.yml](.github/workflows/release-pcb.yml) — tags `pcb-*.*.*`, écrit dans `pcb/CHANGELOG.md`, asset `gerber.zip` attaché.
+
+Les deux workflows partagent un `concurrency:` group `release-main` — un push combiné `git push origin main v0.2.0 pcb-0.1.1` sérialise proprement les deux auto-commits `main` sans fenêtre de race.
+
+### Couper une release firmware (`v*`)
 
 1. Se placer sur `main` à jour : `git checkout main && git pull`.
-2. Vérifier qu'il y a des commits [Conventional Commits](https://www.conventionalcommits.org/) depuis le dernier tag.
+2. Vérifier les commits [Conventional Commits](https://www.conventionalcommits.org/) depuis le dernier tag `v*.*.*`.
 3. **Toujours tagger un commit déjà sur `main`** — jamais depuis une feat branch ou un état détaché. La workflow refuse les tags pointant sur un commit absent de `origin/main`.
-4. Pousser le tag et la branche ensemble : `git tag v<x.y.z> && git push origin main v<x.y.z>`.
-5. Vérifier dans l'onglet Actions que la workflow est `success`, puis sur la page [Releases](https://github.com/gaetanars/FrangiPool/releases) que `gerber.zip` est bien attaché.
+4. Pousser le tag : `git tag vX.Y.Z && git push origin main vX.Y.Z`.
+5. Vérifier dans l'onglet Actions que `release-firmware.yml` est `success`, puis sur la page [Releases](https://github.com/gaetanars/FrangiPool/releases) que la nouvelle release est créée (firmware n'attache pas d'asset — c'est attendu).
 
-Le tag doit matcher la regex `v[0-9]+.[0-9]+.[0-9]+` (pas de suffixes `-rc`, `-test`, etc. — ceux-là ne déclenchent pas la workflow).
+Le tag doit matcher la regex `v[0-9]+.[0-9]+.[0-9]+` (pas de suffixes `-rc`, `-test`, etc.).
 
-Pour retagger (force-push d'un tag existant) : supprimer d'abord la release GitHub (`gh release delete v<x.y.z> --yes`), sinon la workflow s'arrête avec une erreur explicite.
+**Retag forward-looking** (corriger un tag qui vient d'être publié) : supprimer d'abord la release GitHub, puis retirer le tag local et remote, puis re-tagger.
+
+```bash
+gh release delete vX.Y.Z --yes
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+# corriger, puis retagger via l'étape 4 ci-dessus
+```
+
+Le retag des tags historiques `v0.0.1` et `v0.1.0` est explicitement hors-scope — ils restent intouchés.
+
+### Couper une release PCB (`pcb-*`)
+
+1. Se placer sur `main` à jour après une modification matérielle (nouveaux Gerbers sous `pcb/src/`).
+2. Vérifier les commits Conventional Commits avec scope `pcb(*)` depuis le dernier tag `pcb-*.*.*`.
+3. Tag sur un commit de `main` : `git tag pcb-X.Y.Z && git push origin main pcb-X.Y.Z`.
+4. Vérifier dans l'onglet Actions que `release-pcb.yml` est `success`, puis sur la page [Releases](https://github.com/gaetanars/FrangiPool/releases) que `gerber.zip` est attaché à `pcb-X.Y.Z` et que le badge "latest release" reste sur la dernière release firmware (PCB publie avec `makeLatest: false`).
+
+Le tag doit matcher la regex `pcb-[0-9]+.[0-9]+.[0-9]+`. Le premier tag PCB sous ce schéma est `pcb-0.1.1`, diffé contre le seed baseline `pcb-0.1.0`.
+
+> **Seed baseline tag — `pcb-0.1.0`**
+>
+> Le tag `pcb-0.1.0` est un seed baseline immutable posé sur le commit d'import monorepo (`7ea5eab feat(pcb): import hardware design from frangipool/pcb@cfd2e9f`). **NE JAMAIS le supprimer, le déplacer, ni le retagger.** Il sert d'ancre pour `git tag --list 'pcb-*'` et sa disparition casserait le `prev_tag` lookup de toutes les releases PCB futures. Si le tag est pushé par erreur (p.ex. après merge), `release-pcb.yml` saute proprement via son guard `if: github.ref_name != 'pcb-0.1.0'` — aucune release créée.
+
+**Retag forward-looking** d'un tag PCB (`pcb-0.1.1` ou suivant) : même procédure que pour firmware, substituer le prefix.
+
+```bash
+gh release delete pcb-X.Y.Z --yes
+git tag -d pcb-X.Y.Z
+git push origin :refs/tags/pcb-X.Y.Z
+# corriger, puis retagger via l'étape 3 ci-dessus
+```
 
 ## Relais Active-LOW
 

--- a/docs/brainstorms/2026-04-23-001-split-release-tags-requirements.md
+++ b/docs/brainstorms/2026-04-23-001-split-release-tags-requirements.md
@@ -1,0 +1,115 @@
+---
+date: 2026-04-23
+topic: split-release-tags
+---
+
+# Split firmware and PCB releases into independent tag-triggered workflows
+
+## Problem Frame
+
+Le monorepo partage aujourd'hui une seule workflow [release.yml](../../.github/workflows/release.yml) déclenchée par les tags `v[0-9]+.[0-9]+.[0-9]+`. Chaque release bundle firmware + `gerber.zip`, même quand le PCB n'a pas changé. L'unique CHANGELOG à la racine mélange les deux historiques et une note conditionnelle `"PCB inchangé depuis X"` est injectée dans le body pour dissiper l'ambiguïté.
+
+Résultat : firmware et PCB partagent un cycle de vie forcé. Un patch PCB oblige à bumper le firmware (et inversement), la release d'un composant pollue les notes de l'autre, et la conditionnelle de composition de body est le genre d'asymétrie qui tend à s'étendre à chaque nouveau cas particulier.
+
+Le changement cible : deux workflows miroirs, chacune déclenchée par son propre préfixe de tag, chacun écrivant dans son propre CHANGELOG. Cycle de vie indépendant, zéro conditionnelle de scope dans la CI.
+
+**Reframe assumé** : la douleur citée (note PCB-inchangé conditionnelle + CHANGELOG mixte) est un symptôme ; le remède choisi est la division des cycles de vie, pas le minimum pour éliminer la conditionnelle actuelle. Ce choix est volontairement plus ambitieux que "simplifier la CI".
+
+**Coût du statu quo** : la conditionnelle `PCB-inchangé` n'a pas encore tiré en production (le monorepo merge est récent, aucune release depuis). Historique PCB depuis `frangipool/pcb@v0.1.0` (2023-06-08) : une seule révision matérielle sur ~3 ans. Cadence PCB attendue ≤1/an. Les deux workflows miroirs introduisent ~20 lignes dupliquées (R3) contre une conditionnelle existante de ~15 lignes dans `release.yml` — coût récurrent similaire. Le gain : la classe entière de conditionnelles "est-ce que l'autre composant a changé" disparaît, pas seulement la conditionnelle existante. À cadence PCB ~1/an le gain est modeste mais durable si la surface PCB s'active.
+
+## Requirements
+
+**Release workflows**
+
+- R1. Le tag `vX.Y.Z` déclenche exclusivement une release firmware (pas de `gerber.zip` attaché).
+- R2. Le tag `pcb-X.Y.Z` déclenche exclusivement une release PCB (asset `gerber.zip` obligatoire, validé via le pattern `grep -qE '\.(GTL|GBL|GKO|GBS|GTO|GTS|DRL)$'` hérité de la Garde C12 actuelle de [release.yml](../../.github/workflows/release.yml)).
+- R3. Les deux workflows conservent les garde-fous existants de [release.yml](../../.github/workflows/release.yml) : tag-sur-`origin/main`, refus si la release existe déjà, ordering commit-CHANGELOG-puis-publish, heredoc à délimiteur aléatoire, `timeout-minutes: 15`, pinning SHA des actions tierces. Elles partagent un `concurrency:` group `release-main` pour sérialiser tout accès à `main` (auto-commit CHANGELOG) en cas de push simultané de tags `v*` et `pcb-*` sur le même commit.
+- R4. La workflow PCB publie avec `makeLatest: false`. La workflow firmware conserve `makeLatest: legacy`.
+- R5. La conditionnelle "PCB inchangé depuis X" disparaît (plus de body composé dynamiquement).
+
+**CHANGELOG**
+
+- R6. `CHANGELOG.md` à la racine devient le changelog firmware seul. La workflow firmware invoque `requarks/changelog-action` en mode `fromTag`/`toTag` (voir Key Decisions) avec `excludeScopes: changelog,pcb` et `changelogFilePath: CHANGELOG.md`.
+- R7. `pcb/CHANGELOG.md` devient le changelog PCB seul. La workflow PCB invoque `requarks/changelog-action` en mode `fromTag`/`toTag` avec `excludeScopes: changelog` et `changelogFilePath: pcb/CHANGELOG.md`.
+- ~~R8~~ (retiré — voir Scope Boundaries). La section "Pre-monorepo history" de `CHANGELOG.md` reste inchangée ; le bootstrap via tag annotated `pcb-0.1.0` (R9) donne à `pcb/CHANGELOG.md` sa baseline reachable sans manipulation manuelle des entrées archivales.
+
+**Migration et continuité**
+
+- R9. Premier tag PCB sous le nouveau schéma : `pcb-0.1.1` (continuation directe du `v0.1.0` importé depuis `frangipool/pcb`). **Bootstrap** : pousser d'abord un tag annotated `pcb-0.1.0` sur le commit d'import monorepo (`7ea5eab feat(pcb): import hardware design from frangipool/pcb@cfd2e9f`) pour donner à `git tag --list 'pcb-*' --sort=-v:refname` une baseline reachable. Alternative (choix de planning) : la workflow PCB gère explicitement le cas "pas de tag `pcb-*` précédent" en diffant contre ce SHA d'import pour le premier run uniquement — ajoute une branche temporaire à la workflow, décision à trancher en planning.
+- R10. Prochain tag firmware sous le nouveau schéma : semver suivant (ex. `v0.2.0` ou `v0.1.1` selon le contenu). Aucun retagging des tags existants `v0.0.1` / `v0.1.0`.
+
+**Documentation**
+
+- R11. La section "Couper une release" de [README.md](../../README.md) est scindée en deux procédures distinctes : une pour firmware (`v*`), une pour PCB (`pcb-*`). La regex de chaque workflow et la procédure de tag initial et de correction forward-looking (delete release + retag après coup) sont documentées par composant — distincte de l'exclusion historique en Scope Boundaries.
+
+## Visual Aid
+
+```
+Avant (unifié) :
+  tag vX.Y.Z  --->  release.yml  --->  CHANGELOG.md (tout)
+                                       + gerber.zip attaché (toujours)
+                                       + "PCB inchangé depuis …" si applicable
+
+Après (split) :
+  tag vX.Y.Z      --->  release-firmware.yml  --->  CHANGELOG.md (firmware)
+                                                    pas d'asset
+                                                    fromTag/toTag (prev v*)
+                                                    excludeScopes: changelog,pcb
+                                                    makeLatest: legacy
+
+  tag pcb-X.Y.Z   --->  release-pcb.yml       --->  pcb/CHANGELOG.md (PCB)
+                                                    gerber.zip (validé)
+                                                    fromTag/toTag (prev pcb-*)
+                                                    excludeScopes: changelog
+                                                    makeLatest: false
+
+  concurrency group partagé `release-main` entre les deux workflows.
+```
+
+## Success Criteria
+
+- Publier une révision PCB (ex. `pcb-0.1.1`) ne crée aucun effet de bord sur le badge "latest release", sur `CHANGELOG.md`, ou sur les notes d'une future release firmware.
+- Publier un firmware (ex. `v0.2.0`) ne produit aucun `gerber.zip` et n'imprime aucune mention de l'état du PCB dans le body.
+- Chacune des deux workflows est lisible de haut en bas sans branche conditionnelle liée à "est-ce que l'autre composant a changé".
+- Les garde-fous énumérés en R3 sont présents dans les deux fichiers — la duplication est assumée (cf. Key Decisions).
+
+## Scope Boundaries
+
+- **Hors scope : extraire les garde-fous partagés (tag-sur-main, release-exists, heredoc, step summary) en composite action `.github/actions/release-guard`.** La duplication de ~20 lignes entre deux fichiers est acceptée ; une composite action recréerait une dépendance partagée qui pollue exactement la séparation qu'on cherche à établir.
+- **Hors scope : splitter `validate.yml`.** Le `paths-ignore` actuel est une optimisation de déclenchement, pas une conditionnelle sémantique. Laisser tel quel.
+- **Hors scope : retagging des tags existants `v0.0.1` / `v0.1.0`.** Historiques, non republiables.
+- **Hors scope : ajout d'un asset firmware (binaire compilé ESPHome, archive des presets, etc.).** Les presets sont consommés directement depuis `github://` ; une release sans asset reste fonctionnelle.
+- **Hors scope : ajout d'une validation CI des Gerbers sur les PR qui touchent `pcb/`.** Peut venir plus tard si la surface PCB s'active, aujourd'hui non justifié.
+- **Hors scope : redécouper la section "Pre-monorepo history" de `CHANGELOG.md`.** Le bootstrap via tag annotated `pcb-0.1.0` (R9) donne déjà à `pcb/CHANGELOG.md` une baseline reachable. Les entrées archivales (firmware v0.1.0 + pcb v0.1.0 + URLs `frangipool/pcb`) restent inchangées — aucun édit manuel de contenu archival.
+
+## Key Decisions
+
+- **Tag firmware reste `vX.Y.Z`** : préserve la continuité avec l'historique (`v0.0.1`, `v0.1.0`) et la convention usuelle "v = code release". L'asymétrie avec `pcb-X.Y.Z` est le prix à payer pour ne pas casser deux tags.
+- **Deux CHANGELOGs séparés** : seul moyen d'avoir un vrai cycle de vie indépendant sans scope-filtering acrobatique. `pcb/CHANGELOG.md` existe déjà (archive de l'ancien dépôt), il devient le changelog vivant du PCB.
+- **Filtrage par range scopée au composant (`fromTag`/`toTag`)** : les deux workflows utilisent le mode `fromTag`/`toTag` de `requarks/changelog-action` avec le `toTag` précalculé par une step shell `git tag --list '<prefix>*' --sort=-v:refname | sed -n '2p'`. Le mode `tag:` par défaut du action fait un `git describe` non-préfixé — il renverrait le dernier tag toutes catégories confondues (ex : `v0.2.0` lors d'un run sur `pcb-0.1.1`), provoquant soit un échec `Provided tag doesn't match latest tag`, soit un changelog PCB rempli de commits firmware. `fromTag`/`toTag` court-circuitent ce lookup. Firmware exclut aussi `scope(pcb)` pour couvrir les rares commits touchant `pcb/` en dehors d'un tag PCB.
+- **PCB `makeLatest: false`** : les releases PCB ne doivent jamais déplacer le badge "latest release" de GitHub, qui reste réservé au firmware — composant avec le cycle de vie le plus actif.
+- **Pas d'extraction en composite action** : YAGNI. Deux fichiers, ~20 lignes dupliquées. L'alternative crée un couplage qu'on supprime justement.
+- **Co-location du code, indépendance des releases** : le merge monorepo (`b5573bb`) a unifié la source-of-truth et l'outillage — acquis préservé. Ce split réintroduit uniquement l'axe de release ; aucun fichier ne bouge, aucune référence croisée ne casse. Firmware et PCB sont deux composants qui co-évoluent sur des cadences différentes, et les deux workflows reflètent cette asymétrie sans la recréer au niveau du code.
+
+## Dependencies / Assumptions
+
+- `requarks/changelog-action@v1.10.3` accepte l'input `changelogFilePath` (default `CHANGELOG.md`) qui supporte un chemin arbitraire incluant `pcb/CHANGELOG.md` — vérifié dans l'action.yml au SHA `b78a3354`.
+- Le mode `fromTag`/`toTag` de `requarks/changelog-action` accepte des valeurs de tag arbitraires (bypass du lookup GraphQL par commit-date). Le `toTag` vide (premier run d'un préfixe, avant le tag bootstrap) doit être géré explicitement par la step shell — cf. R9.
+- Les guards actuels (tag-on-main, release-exists, heredoc) sont portables tels quels dans les deux nouvelles workflows — aucune dépendance à la nature "firmware vs PCB" du tag.
+- Aucune automatisation externe (GitHub Apps, webhooks downstream) ne consomme actuellement les releases avec une attente sur le prefix `v*`. Si cette supposition est fausse, ajouter une note de compatibilité dans R11.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+_(aucune — toutes les décisions produit sont prises)_
+
+### Deferred to Planning
+
+- [Affects R6, R7][Technical] L'input `changelogFilePath` est confirmé comme supportant `pcb/CHANGELOG.md`. Reste à valider en planning que l'action génère un body cohérent quand le fichier cible n'existe pas encore à la racine attendue (comportement initial).
+- [Affects R9][Technical] Choix entre (a) tag annotated `pcb-0.1.0` baseline sur le commit d'import, (b) branche de workflow gérant le cas "pas de tag `pcb-*` précédent". Option (a) recommandée par simplicité — à trancher en planning.
+- [Affects R11][Technical] Le `dashboard_import.package_import_url` des presets pointe sur `@main` ; faut-il ajouter une recommandation dans README pour épingler au dernier tag firmware ? Lié mais non bloquant.
+
+## Next Steps
+
+-> `/ce-plan` for structured implementation planning

--- a/docs/plans/2026-04-23-001-refactor-split-release-tags-plan.md
+++ b/docs/plans/2026-04-23-001-refactor-split-release-tags-plan.md
@@ -1,0 +1,345 @@
+---
+title: "refactor: Split firmware and PCB releases into independent tag-triggered workflows"
+type: refactor
+status: active
+date: 2026-04-23
+origin: docs/brainstorms/2026-04-23-001-split-release-tags-requirements.md
+---
+
+# refactor: Split firmware and PCB releases into independent tag-triggered workflows
+
+## Overview
+
+Remplace la workflow unifiée [release.yml](../../.github/workflows/release.yml) (tag `v*.*.*`, bundle firmware + `gerber.zip`, note conditionnelle "PCB inchangé") par deux workflows miroirs — `release-firmware.yml` sur les tags `v*.*.*` et `release-pcb.yml` sur les tags `pcb-*.*.*`. Chaque workflow écrit dans son propre CHANGELOG, publie un asset correspondant à son composant (aucun pour firmware, `gerber.zip` pour PCB), et partage un `concurrency:` group `release-main` pour sérialiser les commits CHANGELOG sur `main` en cas de push simultané de tags. Le filtrage des release notes se fait via le mode `fromTag`/`toTag` de `requarks/changelog-action` avec le tag précédent précalculé par prefix, éliminant la prefix-blindness de `git describe`.
+
+## Problem Frame
+
+Voir [l'origine](../brainstorms/2026-04-23-001-split-release-tags-requirements.md#problem-frame) pour la motivation produit. Synthèse : firmware et PCB partagent un cycle de vie forcé, la release d'un composant pollue les notes de l'autre, et la conditionnelle de body introduit une asymétrie qui tend à s'étendre. Ce plan matérialise le choix "deux workflows, deux tags, deux CHANGELOGs" décidé dans le brainstorm.
+
+## Requirements Trace
+
+- R1. Tag `vX.Y.Z` déclenche exclusivement une release firmware (pas d'asset) — Unit 2.
+- R2. Tag `pcb-X.Y.Z` déclenche exclusivement une release PCB (asset `gerber.zip` validé via Garde C12) — Unit 3.
+- R3. Garde-fous hérités + concurrency group `release-main` partagé — Units 2, 3.
+- R4. Firmware `makeLatest: legacy`, PCB `makeLatest: false` — Units 2, 3.
+- R5. La conditionnelle "PCB inchangé depuis X" disparaît (suppression de release.yml) — Unit 4.
+- R6. `CHANGELOG.md` firmware seul, mode `fromTag`/`toTag`, `excludeScopes: changelog,pcb` — Unit 2.
+- R7. `pcb/CHANGELOG.md` PCB seul, mode `fromTag`/`toTag`, `excludeScopes: changelog` — Unit 3.
+- R9. Premier tag PCB `pcb-0.1.1`, bootstrap via seed `pcb-0.1.0` annotated — Units 1, 3.
+- R10. Prochain tag firmware semver suivant ; pas de retagging — Unit 5 (runbook) + Documentation/Operational Notes (checklist post-merge).
+- R11. README "Couper une release" scindé en deux procédures — Unit 5.
+
+(R8 retiré du plan, cf. Scope Boundaries.)
+
+## Scope Boundaries
+
+- **Hors scope : extraction des garde-fous partagés en composite action.** ~20 lignes dupliquées entre les deux workflows ; l'alternative recréerait un couplage qu'on supprime justement.
+- **Hors scope : splitter `validate.yml`.** Le `paths-ignore` existant reste tel quel.
+- **Hors scope : retagging de `v0.0.1` / `v0.1.0`.** Historiques, intouchés.
+- **Hors scope : ajout d'un asset sur les releases firmware.** Les presets sont consommés via `github://`, pas besoin d'archive.
+- **Hors scope : validation CI des Gerbers sur les PRs qui touchent `pcb/`.** À faire plus tard si la surface PCB s'active.
+- **Hors scope : redécouper la section "Pre-monorepo history" de `CHANGELOG.md`.** Le seed tag `pcb-0.1.0` donne à `pcb/CHANGELOG.md` sa baseline reachable sans édit manuel.
+- **Hors scope : recommandation de pinning `@main` → tag firmware dans les presets.** Concern séparé, non bloquant.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- [.github/workflows/release.yml](../../.github/workflows/release.yml) — workflow actuel (117 lignes, 8 failure modes mitigés en commit `cf1d2c3`). Sert de base dont les deux nouvelles héritent les garde-fous.
+- [.github/workflows/validate.yml](../../.github/workflows/validate.yml) — pattern pour SHA-pinning et minimal permissions.
+- [CHANGELOG.md](../../CHANGELOG.md) + [pcb/CHANGELOG.md](../../pcb/CHANGELOG.md) — déjà existants ; `pcb/CHANGELOG.md` contient un `## [v0.1.0] - 2023-06-08` archival qui sert d'ancre d'insertion pour `requarks/changelog-action`.
+- [README.md](../../README.md) ligne 254 "Couper une release" — section à scinder en deux.
+
+### Institutional Learnings
+
+- [docs/solutions/architecture/tag-triggered-release-workflow-hardening.md](../solutions/architecture/tag-triggered-release-workflow-hardening.md) — les 8 garde-fous hardenés (heredoc délimiteur aléatoire, commit-avant-publish, fail-fast si release existe, makeLatest legacy, timeout, asset validation, prev-tag via git describe, README runbook) transfèrent verbatim aux deux nouvelles workflows. Le document mentionne aussi 5 residual risks dont `concurrency:` group — ce plan résout celui-là via le group partagé.
+
+### External References
+
+- Vérification directe du source `Requarks/changelog-action@b78a3354` : l'action expose `fromTag` + `toTag` comme inputs alternatifs au mode `tag:`, bypassant le lookup GraphQL `refs(first: 2, orderBy: TAG_COMMIT_DATE)` qui est la cause racine de la prefix-blindness. Input de fichier : `changelogFilePath` (default `CHANGELOG.md`).
+
+## Key Technical Decisions
+
+- **Mode `fromTag`/`toTag` avec tag précédent calculé en shell step** (R6, R7). Le mode par défaut `tag:` utilise `git describe` sans filtre de préfixe, ce qui sur `pcb-0.1.1` renvoie le dernier tag toutes catégories (`v0.2.0`) et pollue le changelog ou fait échouer l'action (`latestTag.name !== tag`). Pattern shell hardené : `prev_tag=$(git tag --list '<prefix>*' --sort=-v:refname | grep -v -Fx "${github.ref_name}" | head -n1)` suivi d'un guard `if [ -z "$prev_tag" ]; then echo '::error::No previous <prefix>-* tag found.'; exit 1; fi`. Le `grep -v -Fx` retire le tag courant par nom (pas par position), ce qui reste correct sur un retag forward-looking d'une version non-latest ; le guard empty rend l'erreur de bootstrap (seed tag manquant, tag supprimé manuellement) bruyante au lieu de silencieuse.
+- **Concurrency group `release-main` partagé entre les deux workflows** (R3). Sérialise tout accès à `main` (auto-commit CHANGELOG) en cas de push simultané `git push origin main v0.2.0 pcb-0.1.1`. `cancel-in-progress: false` pour queuer, pas interrompre. Per-workflow groups (`release-firmware` vs `release-pcb`) ne résoudraient PAS la race : elles serialisent les retags d'un même composant, pas la contention sur `main` entre composants.
+- **Bootstrap PCB via seed tag annotated `pcb-0.1.0` sur le commit `7ea5eab`** (R9). Alternative (workflow-level special case "no previous tag") rejetée : ajoute une branche conditionnelle dans la workflow exercée une seule fois, coût permanent vs coût one-shot d'un tag push. Le seed tag reste protégé par un guard `if: github.ref_name != 'pcb-0.1.0'` au niveau job dans release-pcb.yml, rendant la workflow idempotente à un push du seed fait par erreur après merge — l'ordering Unit 1 avant PR merge devient une recommandation, plus une dépendance dure.
+- **Tag-on-main guard refname-exact** (R3, inherited-and-upgraded). Au lieu de `git branch -r --contains "$SHA" | grep -q 'origin/main$'` (faux positif si un autre remote ou une branche `feat-main` existe — résidu connu de la learning doc), utiliser `git branch -r --contains "$SHA" --format='%(refname)' | grep -Fxq 'refs/remotes/origin/main'`. Match exact sur le refspec complet, immunisé au suffixe.
+- **Conservation du glob de trigger identique au regex de l'origine** : `v[0-9]+.[0-9]+.[0-9]+` et `pcb-[0-9]+.[0-9]+.[0-9]+`. Rejette les suffixes `-rc`, `-test`, `-beta` — alignement avec la procédure documentée dans le README actuel.
+- **Retrait de release.yml dans la même PR que l'ajout des deux nouvelles workflows** (Unit 5). Évite la fenêtre temporelle où (a) ajouter avant retirer déclencherait DEUX workflows sur le même tag `v*`, ou (b) retirer avant ajouter perdrait la release. Atomicité via PR unique.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **`changelogFilePath` supporte-t-il un chemin imbriqué (`pcb/CHANGELOG.md`) ?** Oui — vérifié dans action.yml à SHA `b78a3354` durant le review.
+- **Le fichier cible doit-il préexister pour que l'action génère un body cohérent ?** Oui et c'est déjà le cas — `pcb/CHANGELOG.md` contient un H2 archival `## [v0.1.0] - 2023-06-08` qui sert d'ancre d'insertion. L'action insère les nouvelles entrées au-dessus du premier H2.
+- **Sort stability de `git tag --list --sort=-v:refname` pour préfixes différents ?** Le glob `--list 'pcb-*'` filtre avant le sort. `-v:refname` gère correctement le tri semver à préfixe constant (ex : `pcb-0.1.10` > `pcb-0.1.2`). Le pattern shell hardené (skip-by-name via `grep -v -Fx`) est en plus indépendant de la position du tag courant, donc correct pour retag non-monotonique.
+- **Le seed tag `pcb-0.1.0` déclenche-t-il un workflow existant ?** Non — le trigger actuel de release.yml est `v[0-9]+.[0-9]+.[0-9]+`, qui ne matche pas `pcb-*`. Seed push safe.
+
+### Deferred to Implementation
+
+- **Exact wording** de `permissions:` pour release-pcb.yml — à dériver du current release.yml (`contents: write`) qui couvre à la fois `release-action` et `git-auto-commit-action`.
+- **Comportement de `ncipollo/release-action` avec `makeLatest: false` + `allowUpdates: true`** sur un retag — à observer au premier retag PCB réel. Pattern attendu : replace assets sans bouger le badge latest. Fallback : `gh release delete` puis retag.
+- **Dry-run mechanism via `workflow_dispatch`** — pour dé-risquer la première release réelle, évaluer l'ajout d'un input booléen `dry_run` aux deux workflows qui saute l'auto-commit et release-create en imprimant le plan au `$GITHUB_STEP_SUMMARY`. Ajouté ~20 lignes/workflow + une sous-section README. Laissé en deferred : évaluer après la première release réelle ou si un bug post-merge justifie le coût d'ajout. Réduirait le résidual risk "no dry-run path" identifié dans la learning doc.
+
+## High-Level Technical Design
+
+> *Ce diagramme illustre les flux après le split — directional guidance pour review, pas spécification d'implémentation.*
+
+```
+Push commit --> main
+                 │
+                 ├── Push tag v0.2.0 ────────────────────┐
+                 │                                        │
+                 └── Push tag pcb-0.1.1 ───────────┐      │
+                                                    │      │
+                                                    ▼      ▼
+                                   release-pcb.yml    release-firmware.yml
+                                       │                   │
+                                       ├── guard: tag on origin/main
+                                       ├── guard: release-exists pre-check
+                                       ├── shell: prev_tag=git tag --list 'pcb-*' ...
+                                       ├── changelog-action (fromTag/toTag)
+                                       │     → pcb/CHANGELOG.md
+                                       ├── zip Gerbers + validate C12
+                                       ├── compose body (heredoc randomisé)
+                                       ├── git-auto-commit-action pcb/CHANGELOG.md
+                                       │        ├────── concurrency: release-main ───────┤
+                                       │                                                  │
+                                       └── ncipollo/release-action                        │
+                                            - makeLatest: false                           │
+                                            - gerber.zip asset                            │
+                                                                                          │
+                                                                         shell: prev_tag=git tag --list 'v*' ...
+                                                                         changelog-action (fromTag/toTag)
+                                                                             → CHANGELOG.md (excludeScopes: changelog,pcb)
+                                                                         compose body
+                                                                         git-auto-commit-action CHANGELOG.md
+                                                                         ncipollo/release-action
+                                                                             - makeLatest: legacy
+                                                                             - aucun asset
+```
+
+Le `concurrency: release-main` serialise les jobs de bout en bout : une seule workflow à la fois depuis le checkout jusqu'à la publication de release. C'est une sur-mitigation volontaire — on accepte la latence additionnelle sur un push combiné pour éliminer toute fenêtre de race sur `main`, et les releases GitHub n'ayant pas d'état partagé, la sérialisation complète n'introduit aucun coût de correction.
+
+## Implementation Units
+
+- [ ] **Unit 1: Push seed annotated tag `pcb-0.1.0`**
+
+**Goal:** Donner à `git tag --list 'pcb-*' --sort=-v:refname` une baseline reachable pour le premier vrai tag PCB sous le nouveau schéma.
+
+**Requirements:** R9.
+
+**Dependencies:** Aucune (doit précéder Unit 2, mais no-op pour la CI actuelle).
+
+**Files:**
+- Aucun fichier modifié. Action locale `git tag -a pcb-0.1.0 7ea5eab -m "..." && git push origin pcb-0.1.0`.
+
+**Approach:**
+- Tag annotated (pas lightweight) pour porter le message descriptif "Baseline imported from frangipool/pcb@v0.1.0 — seed for post-monorepo pcb-* release series".
+- Cible le commit d'import `7ea5eab feat(pcb): import hardware design from frangipool/pcb@cfd2e9f`.
+- Push avant le merge de la PR qui introduit `release-pcb.yml` : le trigger actuel `v[0-9]+.[0-9]+.[0-9]+` ne matche pas `pcb-*`, donc aucun workflow ne s'exécute.
+
+**Patterns to follow:**
+- Procédure de tag documentée dans [README.md "Couper une release"](../../README.md) (à scinder par Unit 5).
+
+**Test scenarios:**
+- Test expectation: none — opération one-shot de bootstrap tag, pas de comportement à couvrir.
+
+**Verification:**
+- `git ls-remote --tags origin | grep pcb-0.1.0` retourne le tag.
+- Aucun run GitHub Actions ne s'est déclenché sur le push (vérifier l'onglet Actions).
+
+---
+
+- [ ] **Unit 2: Create `.github/workflows/release-firmware.yml`**
+
+**Goal:** Workflow tag-triggered pour les releases firmware, miroir du current release.yml sans la logique PCB.
+
+**Requirements:** R1, R3, R4, R6.
+
+**Dependencies:** Unit 1 (pour l'atomicité PR).
+
+**Files:**
+- Create: `.github/workflows/release-firmware.yml`
+
+**Approach:**
+- Trigger : `on: push: tags: ['v[0-9]+.[0-9]+.[0-9]+']` — identique au current.
+- `permissions: contents: write`, `timeout-minutes: 15`, SHA-pinned actions (copier les SHAs du current release.yml).
+- `concurrency: { group: release-main, cancel-in-progress: false }`.
+- Steps, dans l'ordre :
+  1. `actions/checkout@...` avec `fetch-depth: 0` (requis pour `git describe` et l'historique complet).
+  2. Guard tag-on-main (refname-exact, cf. Key Decisions) : `git fetch origin main && git branch -r --contains "${github.sha}" --format='%(refname)' | grep -Fxq 'refs/remotes/origin/main'`.
+  3. Guard release-already-exists : `gh release view "${github.ref_name}" || proceed`.
+  4. Shell pre-step : calcul du `prev_tag` hardené via `git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v -Fx "${github.ref_name}" | head -n1` → stocker dans `$GITHUB_OUTPUT`. Ajouter un guard `if [ -z "$prev_tag" ]; then echo '::error::No previous v-* tag found. Push a baseline tag first.'; exit 1; fi`.
+  5. `requarks/changelog-action` en mode `fromTag`/`toTag` : `fromTag: ${github.ref_name}`, `toTag: ${steps.prev.outputs.prev_tag}`, `excludeScopes: changelog,pcb`, `excludeTypes: chore,style,build` (hérité du current release.yml pour préserver le filtre de bruit), `changelogFilePath: CHANGELOG.md`.
+  6. Compose body (heredoc délimiteur `BODY_$(openssl rand -hex 16)`). PAS de note "PCB inchangé" — elle disparaît avec le split.
+  7. `stefanzweifel/git-auto-commit-action` : `branch: main`, `commit_message: 'docs(changelog): update CHANGELOG.md for ${github.ref_name} [skip ci]'`, `file_pattern: CHANGELOG.md`.
+  8. `ncipollo/release-action` : `allowUpdates: true`, `makeLatest: legacy`, `body: ${release_notes}`, **pas d'input `artifacts`** (firmware sans asset).
+  9. Step summary logs à chaque étape significative.
+
+**Patterns to follow:**
+- [.github/workflows/release.yml](../../.github/workflows/release.yml) pour les SHAs pinned, la forme du heredoc, la procédure d'ordering commit-avant-publish, et les step summary.
+- [docs/solutions/architecture/tag-triggered-release-workflow-hardening.md](../solutions/architecture/tag-triggered-release-workflow-hardening.md) §1–§8 pour les 8 garde-fous à reproduire.
+
+**Test scenarios:**
+- Happy path : push `v0.2.0` déclenche le run, `CHANGELOG.md` contient une nouvelle entrée `## [v0.2.0] - 2026-04-XX` avec les commits depuis `v0.1.0` excluant scopes `changelog` et `pcb`, une release GitHub est créée avec le body mais sans asset. ("Test" ici est end-to-end sur première release réelle — voir Unit 7.)
+- Edge case : `prev_tag` vide (seed manquant, tag supprimé manuellement) → le guard shell remonte un `::error::No previous v-* tag found` et le job échoue avant toute mutation. L'opérateur pousse le tag baseline manquant ou répare la situation, puis retag.
+- Edge case : retag forward-looking d'une version non-latest (ex : hotfix `v0.2.2` après que `v0.3.0` ait shipped) → le `grep -v -Fx` retire le tag courant par nom, donc `head -n1` renvoie le vrai prédécesseur sémantique même si le tag courant n'est pas en position 1 du sort.
+- Error path : push tag depuis une feat branch non mergée → guard step 2 doit échouer avec `::error::Tag ... points to a commit absent from origin/main.`
+- Error path : retag sans suppression préalable de la release → guard step 3 doit échouer avec message explicite de retag.
+
+**Verification:**
+- `esphome config` / linters YAML parsent le fichier sans erreur (`actionlint` optionnel si installé).
+- Dry-run conceptuel : relire le fichier contre la checklist des 8 garde-fous dans la learning doc.
+
+---
+
+- [ ] **Unit 3: Create `.github/workflows/release-pcb.yml`**
+
+**Goal:** Workflow tag-triggered pour les releases PCB, avec zip Gerbers validé, écriture dans `pcb/CHANGELOG.md`, et badge `latest` inchangé.
+
+**Requirements:** R2, R3, R4, R7, R9.
+
+**Dependencies:** Unit 1 (seed `pcb-0.1.0` doit exister pour que le shell pre-step trouve un prev tag sur `pcb-0.1.1`).
+
+**Files:**
+- Create: `.github/workflows/release-pcb.yml`
+
+**Approach:**
+- Trigger : `on: push: tags: ['pcb-[0-9]+.[0-9]+.[0-9]+']`.
+- **Seed-tag idempotence guard** : au niveau job, `if: github.ref_name != 'pcb-0.1.0'` pour que le push du seed tag (accidentel ou volontaire) ne produise aucune release. Imprimer une ligne `$GITHUB_STEP_SUMMARY` explicite quand le guard saute ("Seed baseline tag skipped — no release created."). Rend la workflow idempotente à un push post-merge du seed, supprimant la dépendance d'ordering dure vs Unit 1.
+- `permissions`, `timeout`, SHA-pinning, `concurrency: { group: release-main }` identiques à Unit 2.
+- Steps additionnels vs Unit 2 :
+  - Pre-step calcule le prev tag avec glob `pcb-*` au lieu de `v*` — même pattern hardené (grep -v -Fx + head -n1 + guard empty).
+  - Guard tag-on-main refname-exact (identique à Unit 2).
+  - Après l'action changelog, insère **avant le git-auto-commit** : `cd pcb/src && zip -r ../../gerber.zip .` puis validation C12 via `unzip -l gerber.zip | grep -qE '\.(GTL|GBL|GKO|GBS|GTO|GTS|DRL)$'`.
+  - Compose body : PAS de note "PCB inchangé" non plus (un tag `pcb-*` implique que le PCB a changé par construction).
+  - `git-auto-commit-action` avec `file_pattern: pcb/CHANGELOG.md` et `commit_message: 'docs(changelog): update pcb/CHANGELOG.md for ${github.ref_name} [skip ci]'` (nommage explicite du fichier touché pour l'audit trail).
+  - `ncipollo/release-action` avec `makeLatest: false`, `artifacts: gerber.zip`.
+- `changelog-action` inputs : `excludeScopes: changelog`, `excludeTypes: chore,style,build` (hérité du current release.yml), `changelogFilePath: pcb/CHANGELOG.md`.
+
+**Patterns to follow:**
+- Identique à Unit 2 — le squelette est le même, seules les valeurs diffèrent (glob, chemin CHANGELOG, makeLatest, présence de l'asset).
+
+**Test scenarios:**
+- Happy path : push `pcb-0.1.1` → run, `pcb/CHANGELOG.md` gagne une nouvelle entrée insérée au-dessus du `## [v0.1.0] - 2023-06-08` archival, release GitHub créée avec `gerber.zip` attaché, badge "latest release" reste sur le dernier firmware.
+- Edge case : `pcb/src/` accidentellement vide → zip produit, `unzip -l` ne matche pas le pattern C12 → step échoue avec `::error::gerber.zip is missing Gerber/DRL files`.
+- Error path : tag poussé sur feat branch → guard tag-on-main échoue.
+- Error path : `pcb-0.1.1` retagé sans supprimer la release → guard release-exists échoue.
+- Integration : après le run, `git log origin/main` contient `docs(changelog): update pcb/CHANGELOG.md for pcb-0.1.1 [skip ci]` (nom explicite du fichier, cf. Approach).
+- Edge case : push accidentel de `pcb-0.1.0` après merge → le guard `if: github.ref_name != 'pcb-0.1.0'` fait skipper le job ; step summary affiche "Seed baseline tag skipped" ; aucune release créée.
+
+**Verification:**
+- Lint YAML OK.
+- Checklist des 8 garde-fous + asset validation C12 présente.
+
+---
+
+- [ ] **Unit 4: Remove `.github/workflows/release.yml`**
+
+**Goal:** Supprimer la workflow unifiée pour éviter le double-déclenchement sur tag `v*`.
+
+**Requirements:** R5 (suppression de la conditionnelle PCB-inchangé, qui vit dans release.yml).
+
+**Dependencies:** Units 2, 3 — doit être **dans le même commit / PR** que l'ajout des deux nouvelles workflows pour éviter :
+- (a) fenêtre avec release.yml + release-firmware.yml tous deux actifs → double release sur `v0.2.0`
+- (b) fenêtre sans release.yml avant release-firmware.yml → release perdue
+
+**Files:**
+- Delete: `.github/workflows/release.yml`
+
+**Approach:**
+- Suppression simple via `git rm`. Tout le contenu migre dans les deux nouvelles workflows.
+
+**Patterns to follow:**
+- N/A (suppression).
+
+**Test scenarios:**
+- Test expectation: none — suppression atomique dans la même PR que Units 2 et 3.
+
+**Verification:**
+- `git diff --stat` montre release.yml supprimé, release-firmware.yml + release-pcb.yml ajoutés dans le même commit ou la même PR.
+- `gh workflow list` après merge : plus de "Release" standalone, seulement les deux nouvelles.
+
+---
+
+- [ ] **Unit 5: Update [README.md](../../README.md) "Couper une release" section**
+
+**Goal:** Scinder la procédure actuelle en deux runbooks — un firmware, un PCB — distincts et auto-suffisants.
+
+**Requirements:** R11.
+
+**Dependencies:** Units 2, 3 (les procédures référencent les fichiers créés).
+
+**Files:**
+- Modify: `README.md` (section "Couper une release", autour ligne 254).
+
+**Approach:**
+- Remplacer la section unique par deux sous-sections : `### Couper une release firmware (v*)` et `### Couper une release PCB (pcb-*)`.
+- Chaque sous-section documente : regex de trigger, checklist de pré-vol (`git status`, vérifier les commits Conventional Commits depuis le dernier tag matching), commande de tag push (`git tag vX.Y.Z && git push origin main vX.Y.Z`), commande de retag forward-looking (`gh release delete <tag> --yes && git tag -d <tag> && git push origin :refs/tags/<tag>` puis re-tagger), et vérification post-run (Actions tab + Releases page).
+- Distinguer clairement retag forward-looking (en scope) vs. retag historique `v0.0.1`/`v0.1.0` (hors scope, cité ailleurs).
+- **Guardrail seed tag PCB (critique) :** ajouter un encart explicite dans la sous-section PCB : `Le tag pcb-0.1.0 est un seed baseline immutable — NE JAMAIS le supprimer, le déplacer, ni le retagger. Il sert d'ancre pour git tag --list 'pcb-*' et sa disparition casse le prev_tag lookup de toutes les releases PCB futures.` La procédure de retag documentée s'applique explicitement aux tags `pcb-0.1.1` et suivants.
+- Mettre à jour la phrase "Une release unifiée (firmware + `gerber.zip`)" qui ne s'applique plus.
+
+**Patterns to follow:**
+- Le runbook actuel dans [README.md:254](../../README.md) — structure à préserver (mêmes puces, mêmes types de garde-fou documentés), seulement dupliqué.
+
+**Test scenarios:**
+- Test expectation: none — document d'utilisateur, verif. humaine lors de la review.
+
+**Verification:**
+- Lecture par un opérateur qui ne connaît pas le changement : doit pouvoir couper une release firmware ET PCB sans chercher ailleurs.
+- Pas de référence résiduelle à `release.yml` (singulier) ni à "release unifiée".
+
+## System-Wide Impact
+
+- **Interaction graph:** Les deux workflows interagissent uniquement via `main` (auto-commit CHANGELOG) et via le mécanisme `concurrency:`. Pas d'autre point de synchronisation. Le dashboard HA (homeassistant/dashboard/frangipool.yaml) n'est pas impacté — il ne consomme pas de release artifacts.
+- **Error propagation:** Un guard qui échoue tôt (tag-on-main, release-exists) fait échouer le job entier avant toute mutation visible — comportement identique au current release.yml. La nouveauté : si `release-firmware.yml` échoue à committer `CHANGELOG.md` à cause d'une race `main` (normalement bloquée par concurrency), le `git-auto-commit-action` remonte l'erreur et la release GitHub n'est pas créée (ordering commit-avant-publish préservé).
+- **State lifecycle risks:** Double-trigger si Unit 4 ne land pas dans la même PR que Units 2-3. Mitigation : atomicité PR explicite dans les dépendances d'Unit 4.
+- **API surface parity:** Les consommateurs éventuels du badge `latest release` voient un comportement équivalent (firmware continue à déterminer "latest" via semver). Les consommateurs de `gerber.zip` ne voient plus l'asset sur les tags `v*` — seulement sur `pcb-*`. À signaler dans la description de release si des utilisateurs externes pinnaient sur l'asset firmware pour récupérer les Gerbers.
+- **Integration coverage:** Unit 7 couvre le seul scénario cross-layer réaliste (push simultané).
+- **Unchanged invariants:** `validate.yml` reste identique. La matrice des 8 presets ESPHome continue à s'exécuter sur PR/push de firmware comme avant. Le `paths-ignore: ['pcb/**', 'CHANGELOG.md', 'docs/**', 'README.md']` reste correct.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Double-trigger de workflows sur tag `v*` si release.yml n'est pas retiré dans la même PR que l'ajout de release-firmware.yml | Unit 4 dependency explicit sur atomicité ; revue PR doit vérifier le `git diff --stat`. |
+| Seed tag `pcb-0.1.0` pushé APRÈS le merge de la PR | Guard `if: github.ref_name != 'pcb-0.1.0'` au niveau job de release-pcb.yml rend la workflow idempotente à ce scénario (pas de release créée, step summary explicite). Unit 1 reste ordonné avant le merge par recommendation. |
+| Seed tag `pcb-0.1.0` supprimé par erreur (housekeeping, confusion avec v0.1.0 historique) → tous les pcb-* suivants cassent | Encart explicite "NE JAMAIS supprimer" dans la section PCB du README (Unit 5). Le guard empty du shell pre-step remonte un `::error::` bruyant si le cas arrive malgré tout. |
+| `makeLatest: false` + `allowUpdates: true` interaction inattendue sur retag PCB | Observer au premier retag réel ; fallback documenté dans Unit 5 (delete + retag via `gh release delete`). |
+| Step `git-auto-commit-action` sur `pcb/CHANGELOG.md` pourrait inclure par erreur d'autres fichiers si `file_pattern` est mal paramétré | `file_pattern` explicite pour chaque workflow (`CHANGELOG.md` vs `pcb/CHANGELOG.md`) ; lint PR. |
+| Concurrency group `release-main` bloque sur un run zombie (p.ex. runner crash) → nouvelle release en queue indéfiniment | `timeout-minutes: 15` libère le slot après 15 min max. GitHub UI permet de cancel manuellement si besoin. |
+| Sed/sort behavior diffère sur macOS vs Linux CI runner | CI tourne sur `ubuntu-latest` ; pattern `sed -n '2p'` + `sort -v:refname` portable Linux. |
+
+## Documentation / Operational Notes
+
+- README.md "Couper une release" (Unit 5) est la source canonique de la procédure runtime.
+- Les docs de solutions existantes (hardening learning) restent valides — les 8 patterns qu'elles décrivent sont préservés dans les deux nouvelles workflows (dont 2 upgrades : refname-exact grep, shell prev_tag hardené).
+- Pas de monitoring externe à mettre en place. L'onglet GitHub Actions suffit pour le MVP.
+- Post-merge, mettre à jour la section `## [Unreleased]` de `CHANGELOG.md` pour noter "CI: split release workflow into firmware + PCB streams" sous type `chore` (le scope `changelog` sera filtré du changelog auto-généré grâce à `excludeScopes: changelog,pcb`).
+
+### Post-merge validation checklist
+
+Non-bloquant pour le merge — à exécuter sur la première paire de releases réelles (`v0.2.0` firmware ou `pcb-0.1.1` PCB, selon ce qui ship en premier). Couvre R10 (prochain tag firmware sous nouveau schéma, pas de retagging des historiques).
+
+- Couper la première release firmware selon la nouvelle procédure du README :
+  - Vérifier que release-firmware.yml déclenche seul, pas release-pcb.yml.
+  - Vérifier que `CHANGELOG.md` a une nouvelle entrée `## [v0.2.0]`, SANS les commits scopés `pcb(*)` ou `changelog(*)` ou types `chore/style/build`.
+  - Vérifier que la release GitHub n'a **aucun asset** attaché.
+  - Vérifier que le badge "latest release" pointe sur `v0.2.0`.
+- Couper la première release PCB selon la procédure PCB :
+  - release-pcb.yml déclenche seul.
+  - `pcb/CHANGELOG.md` reçoit l'entrée `## [pcb-0.1.1]` avec les commits depuis `pcb-0.1.0`, `gerber.zip` attaché et validé C12.
+  - Badge "latest release" **ne bouge pas** — reste sur `v0.2.0` (ou plus récent firmware).
+- Si les deux sont poussés sur le même SHA (`git push origin main v0.2.1 pcb-0.1.2`), vérifier que `concurrency: release-main` sérialise les auto-commits sans non-fast-forward.
+- Si anomalie : archiver screenshots ou logs GitHub Actions dans une issue de suivi et itérer.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-23-001-split-release-tags-requirements.md](../brainstorms/2026-04-23-001-split-release-tags-requirements.md)
+- Related code: [.github/workflows/release.yml](../../.github/workflows/release.yml), [.github/workflows/validate.yml](../../.github/workflows/validate.yml), [README.md](../../README.md)
+- Learning: [docs/solutions/architecture/tag-triggered-release-workflow-hardening.md](../solutions/architecture/tag-triggered-release-workflow-hardening.md)
+- External: `Requarks/changelog-action@b78a3354` — action.yml inspected for `fromTag`/`toTag` + `changelogFilePath` inputs
+- Related PRs: #7 (monorepo merge) — context for commit `7ea5eab` (Unit 1 target)

--- a/docs/plans/2026-04-23-001-refactor-split-release-tags-plan.md
+++ b/docs/plans/2026-04-23-001-refactor-split-release-tags-plan.md
@@ -62,7 +62,7 @@ Voir [l'origine](../brainstorms/2026-04-23-001-split-release-tags-requirements.m
 
 - **Mode `fromTag`/`toTag` avec tag précédent calculé en shell step** (R6, R7). Le mode par défaut `tag:` utilise `git describe` sans filtre de préfixe, ce qui sur `pcb-0.1.1` renvoie le dernier tag toutes catégories (`v0.2.0`) et pollue le changelog ou fait échouer l'action (`latestTag.name !== tag`). Pattern shell hardené : `prev_tag=$(git tag --list '<prefix>*' --sort=-v:refname | grep -v -Fx "${github.ref_name}" | head -n1)` suivi d'un guard `if [ -z "$prev_tag" ]; then echo '::error::No previous <prefix>-* tag found.'; exit 1; fi`. Le `grep -v -Fx` retire le tag courant par nom (pas par position), ce qui reste correct sur un retag forward-looking d'une version non-latest ; le guard empty rend l'erreur de bootstrap (seed tag manquant, tag supprimé manuellement) bruyante au lieu de silencieuse.
 - **Concurrency group `release-main` partagé entre les deux workflows** (R3). Sérialise tout accès à `main` (auto-commit CHANGELOG) en cas de push simultané `git push origin main v0.2.0 pcb-0.1.1`. `cancel-in-progress: false` pour queuer, pas interrompre. Per-workflow groups (`release-firmware` vs `release-pcb`) ne résoudraient PAS la race : elles serialisent les retags d'un même composant, pas la contention sur `main` entre composants.
-- **Bootstrap PCB via seed tag annotated `pcb-0.1.0` sur le commit `7ea5eab`** (R9). Alternative (workflow-level special case "no previous tag") rejetée : ajoute une branche conditionnelle dans la workflow exercée une seule fois, coût permanent vs coût one-shot d'un tag push. Le seed tag reste protégé par un guard `if: github.ref_name != 'pcb-0.1.0'` au niveau job dans release-pcb.yml, rendant la workflow idempotente à un push du seed fait par erreur après merge — l'ordering Unit 1 avant PR merge devient une recommandation, plus une dépendance dure.
+- **Bootstrap PCB via seed tag annotated `pcb-0.1.0` sur le commit `b5573bb`** (R9). **Note d'implémentation (2026-04-23) :** le commit d'import original `7ea5eab` a été squash-merged dans PR #7 et est devenu unreachable depuis `main`. Le seed est donc posé sur le squash-merge `b5573bb feat: fusionner frangipool/pcb dans le monorepo + release workflow (#7)` — premier commit de `main` qui contient `pcb/`. Alternative (workflow-level special case "no previous tag") rejetée : ajoute une branche conditionnelle dans la workflow exercée une seule fois, coût permanent vs coût one-shot d'un tag push. Le seed tag reste protégé par un guard `if: github.ref_name != 'pcb-0.1.0'` au niveau job dans release-pcb.yml, rendant la workflow idempotente à un push du seed fait par erreur après merge — l'ordering Unit 1 avant PR merge devient une recommandation, plus une dépendance dure.
 - **Tag-on-main guard refname-exact** (R3, inherited-and-upgraded). Au lieu de `git branch -r --contains "$SHA" | grep -q 'origin/main$'` (faux positif si un autre remote ou une branche `feat-main` existe — résidu connu de la learning doc), utiliser `git branch -r --contains "$SHA" --format='%(refname)' | grep -Fxq 'refs/remotes/origin/main'`. Match exact sur le refspec complet, immunisé au suffixe.
 - **Conservation du glob de trigger identique au regex de l'origine** : `v[0-9]+.[0-9]+.[0-9]+` et `pcb-[0-9]+.[0-9]+.[0-9]+`. Rejette les suffixes `-rc`, `-test`, `-beta` — alignement avec la procédure documentée dans le README actuel.
 - **Retrait de release.yml dans la même PR que l'ajout des deux nouvelles workflows** (Unit 5). Évite la fenêtre temporelle où (a) ajouter avant retirer déclencherait DEUX workflows sur le même tag `v*`, ou (b) retirer avant ajouter perdrait la release. Atomicité via PR unique.
@@ -133,11 +133,11 @@ Le `concurrency: release-main` serialise les jobs de bout en bout : une seule wo
 **Dependencies:** Aucune (doit précéder Unit 2, mais no-op pour la CI actuelle).
 
 **Files:**
-- Aucun fichier modifié. Action locale `git tag -a pcb-0.1.0 7ea5eab -m "..." && git push origin pcb-0.1.0`.
+- Aucun fichier modifié. Action locale `git tag -a pcb-0.1.0 b5573bb -m "..." && git push origin pcb-0.1.0`. (Cible `b5573bb` plutôt que `7ea5eab` parce que l'import original a été squash-merged et est unreachable depuis `main` — cf. note dans Key Technical Decisions.)
 
 **Approach:**
 - Tag annotated (pas lightweight) pour porter le message descriptif "Baseline imported from frangipool/pcb@v0.1.0 — seed for post-monorepo pcb-* release series".
-- Cible le commit d'import `7ea5eab feat(pcb): import hardware design from frangipool/pcb@cfd2e9f`.
+- Cible le squash-merge `b5573bb feat: fusionner frangipool/pcb dans le monorepo + release workflow (#7)` — le premier commit reachable sur `main` où `pcb/` a atterri.
 - Push avant le merge de la PR qui introduit `release-pcb.yml` : le trigger actuel `v[0-9]+.[0-9]+.[0-9]+` ne matche pas `pcb-*`, donc aucun workflow ne s'exécute.
 
 **Patterns to follow:**
@@ -342,4 +342,4 @@ Non-bloquant pour le merge — à exécuter sur la première paire de releases r
 - Related code: [.github/workflows/release.yml](../../.github/workflows/release.yml), [.github/workflows/validate.yml](../../.github/workflows/validate.yml), [README.md](../../README.md)
 - Learning: [docs/solutions/architecture/tag-triggered-release-workflow-hardening.md](../solutions/architecture/tag-triggered-release-workflow-hardening.md)
 - External: `Requarks/changelog-action@b78a3354` — action.yml inspected for `fromTag`/`toTag` + `changelogFilePath` inputs
-- Related PRs: #7 (monorepo merge) — context for commit `7ea5eab` (Unit 1 target)
+- Related PRs: #7 (monorepo merge) — squash-merge `b5573bb` is the Unit 1 seed target.


### PR DESCRIPTION
## Summary

Firmware and PCB now release on separate tag prefixes with separate CHANGELOGs. `v*.*.*` tags cut a firmware release (`CHANGELOG.md`, no asset). `pcb-*.*.*` tags cut a PCB release (`pcb/CHANGELOG.md`, `gerber.zip` attached, `makeLatest: false`). The unified `release.yml` and its conditional "PCB inchangé" body note are retired.

The split eliminates the forced shared lifecycle: a PCB revision no longer requires a firmware bump (and vice versa), and release notes for either component no longer pull in commits from the other.

## What changed

- **New:** [.github/workflows/release-firmware.yml](.github/workflows/release-firmware.yml) — `v*.*.*` trigger, no asset, `makeLatest: legacy`, writes `CHANGELOG.md`.
- **New:** [.github/workflows/release-pcb.yml](.github/workflows/release-pcb.yml) — `pcb-*.*.*` trigger, `gerber.zip` validated via Garde C12, `makeLatest: false`, writes `pcb/CHANGELOG.md`.
- **Removed:** `.github/workflows/release.yml` — unified workflow + the PCB-unchanged conditional body note.
- **Updated:** [README.md](README.md) "Couper une release" split into two runbooks with an explicit seed-tag guardrail.
- **Seeded:** annotated tag `pcb-0.1.0` on `b5573bb` (the squash-merge where `pcb/` landed on main) as the anchor for `git tag --list 'pcb-*'`. First real PCB release will be `pcb-0.1.1`.

## Key design decisions

- **`fromTag`/`toTag` with a shell pre-step, not the action's `tag:` mode.** `requarks/changelog-action`'s default mode runs a prefix-blind `git describe` — on a `pcb-0.1.1` push it would return the latest firmware tag, producing either an action failure (`latestTag.name !== tag`) or a PCB changelog full of firmware commits. The pre-step computes the component-scoped previous tag with `git tag --list '<prefix>[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v -Fx "${ref}" | head -n1` and fails loudly on empty. Skip-by-name is correct under forward-looking retags of older versions; positional `sed '2p'` would not be.
- **Shared `concurrency: release-main` across both workflows.** Per-workflow groups would only serialize retags of the same component. The real concern is a combined `git push origin main v0.2.0 pcb-0.1.1` racing two CHANGELOG auto-commits against `main`. A shared group closes that window.
- **Refname-exact tag-on-main guard.** `grep 'origin/main$'` → `git branch -r --format='%(refname)' | grep -Fxq 'refs/remotes/origin/main'`. Closes a residual risk from the hardening learning doc — `origin/main$` would match `feat-main` or a second remote's `main`.
- **Seed tag anchors on `b5573bb`, not on the original import commit `7ea5eab`.** PR #7 was squash-merged, so `7ea5eab` is unreachable from `main`. `git merge-base pcb-0.1.0 HEAD` would otherwise return `c73abbf` and pollute the first PCB release notes with the monorepo fusion itself. `b5573bb` — the squash-merge — is the correct anchor for a post-monorepo PCB lifecycle.
- **No composite action for shared guards.** ~20 duplicated lines between the two workflows. Extracting them would recreate the coupling the split was designed to remove.

## Known residual risks

| Risk | Status |
|------|--------|
| TOCTOU on auto-commit if a human push hits `main` between checkout and `git-auto-commit-action` | Shared concurrency closes the workflow-vs-workflow window; human-vs-workflow window fails cleanly (no half-published release) |
| No pre-merge `actionlint` — new workflow YAML is first validated on a real tag push | Tracked as follow-up; would have caught three findings during this PR's code review |
| No `workflow_dispatch` dry-run path | Deferred; revisit after first production use if pain emerges |
| Seed tag `pcb-0.1.0` deletion would break all future PCB releases | Workflow-level guard (`if: github.ref_name != 'pcb-0.1.0'`) + README "NE JAMAIS supprimer" encart. Repo-level tag protection rule recommended but not yet configured |

## Post-Deploy Monitoring & Validation

No CI-level monitoring to configure — the GitHub Actions tab is sufficient. The first real release cycle is the end-to-end test:

- **Firmware (`v0.2.0`):** release-firmware.yml only fires (not release-pcb.yml). `CHANGELOG.md` gets a new `## [v0.2.0]` entry excluding scopes `pcb,changelog` and types `chore,style,build`. No asset attached. "Latest release" badge updates.
- **PCB (`pcb-0.1.1`):** release-pcb.yml only fires. `pcb/CHANGELOG.md` gets a new `## [pcb-0.1.1]` entry above the archived `## [v0.1.0] - 2023-06-08`. `gerber.zip` attached, C12 pattern passes. "Latest release" badge unchanged — stays on firmware.
- **Combined push (`git push origin main v0.2.1 pcb-0.1.2`):** both workflows queue on `release-main`, serialize cleanly. Both releases land without non-fast-forward errors.

Full post-merge checklist in `docs/plans/2026-04-23-001-refactor-split-release-tags-plan.md` under "Post-merge validation checklist". Failure signal: an unexpected asset on a firmware release, missing asset on a PCB release, or a CHANGELOG commit without a corresponding GitHub Release (commit-before-publish drift). Rollback: `gh release delete <tag> --yes`, `git tag -d <tag>`, `git push origin :refs/tags/<tag>`, re-tag after fixing the workflow.

## References

- Origin: `docs/brainstorms/2026-04-23-001-split-release-tags-requirements.md`
- Plan: `docs/plans/2026-04-23-001-refactor-split-release-tags-plan.md`
- Hardening learning: `docs/solutions/architecture/tag-triggered-release-workflow-hardening.md`
- Code review artifact: `.context/compound-engineering/ce-code-review/20260423-072851-f135194c/` — 4 safe_auto applied; P1 seed-tag retarget resolved during review; 2 P2 residuals tracked above

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)